### PR TITLE
Pip module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ year = {2019}
 }
 ```
 
+## pip install
+
+Monodepth2 can be installed through pip 
+```bash
+pip install git+https://github.com/AdityaNG/monodepth2@pip-module
+```
+
+Run the webcam demo with :
+```bash
+python -m monodepth2
+```
+
+To use the class to create a monodepth2 object as follows : 
+```python
+from monodepth2  import monodepth2
+md = monodepth2()
+# Load in a frame
+depth = md.eval(frame)
+```
 
 
 ## ⚙️ Setup

--- a/monodepth2.py
+++ b/monodepth2.py
@@ -1,0 +1,151 @@
+import os
+import numpy as np
+import time
+import PIL.Image as pil
+import torch
+from torchvision import transforms, datasets
+import matplotlib as mpl
+import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+
+import networks
+from layers import disp_to_depth
+from utils import download_model_if_doesnt_exist, monodepth2_models_path
+
+MODEL_NAMES = [
+    "mono_640x192",
+    "stereo_640x192",
+    "mono+stereo_640x192",
+    "mono_no_pt_640x192",
+    "stereo_no_pt_640x192",
+    "mono+stereo_no_pt_640x192",
+    "mono_1024x320",
+    "stereo_1024x320",
+    "mono+stereo_1024x320"
+]
+
+class monodepth2:
+
+    def __init__(self, model_name=MODEL_NAMES[2], no_cuda=False, pred_metric_depth=False) -> None:
+        assert model_name in MODEL_NAMES, "Invalid Model Name"
+        
+        if torch.cuda.is_available() and not no_cuda:
+            self.device = torch.device("cuda")
+            print("GPU Visible")
+        else:
+            self.device = torch.device("cpu")
+            print("GPU not visible; CPU mode")
+        
+        if pred_metric_depth and "stereo" not in model_name:
+            print("Warning: The pred_metric_depth flag only makes sense for stereo-trained KITTI "
+              "models. For mono-trained models, output depths will not in metric space.")
+        
+        download_model_if_doesnt_exist(model_name=model_name)
+        model_path = os.path.join(monodepth2_models_path, model_name)
+
+        print("-> Loading model from ", model_path)
+        encoder_path = os.path.join(model_path, "encoder.pth")
+        self.depth_decoder_path = os.path.join(model_path, "depth.pth")
+
+        # LOADING PRETRAINED MODEL
+        print("   Loading pretrained encoder")
+        self.encoder = networks.ResnetEncoder(18, False)
+        loaded_dict_enc = torch.load(encoder_path, map_location=self.device)
+
+        # extract the height and width of image that this model was trained with
+        self.feed_height = loaded_dict_enc['height']
+        self.feed_width = loaded_dict_enc['width']
+        filtered_dict_enc = {k: v for k, v in loaded_dict_enc.items() if k in self.encoder.state_dict()}
+        self.encoder.load_state_dict(filtered_dict_enc)
+        self.encoder.to(self.device)
+        self.encoder.eval()
+
+        print("   Loading pretrained decoder")
+        self.depth_decoder = networks.DepthDecoder(
+            num_ch_enc=self.encoder.num_ch_enc, scales=range(4))
+
+        loaded_dict = torch.load(self.depth_decoder_path, map_location=self.device)
+        self.depth_decoder.load_state_dict(loaded_dict)
+
+        self.depth_decoder.to(self.device)
+        self.depth_decoder.eval()
+
+        #torch.no_grad()
+        pass
+
+    def eval(self, input_image):
+        
+        with torch.no_grad():
+            # Load image and preprocess
+            
+            input_image = pil.fromarray(input_image)
+            original_width, original_height = input_image.size
+            input_image = input_image.resize((self.feed_width, self.feed_height), pil.LANCZOS)
+            input_image = transforms.ToTensor()(input_image).unsqueeze(0)
+
+            # PREDICTION
+            input_image = input_image.to(self.device)
+            features = self.encoder(input_image)
+            outputs = self.depth_decoder(features)
+
+            disp = outputs[("disp", 0)]
+            disp_resized = torch.nn.functional.interpolate(
+                disp, (original_height, original_width), mode="bilinear", align_corners=False)
+
+
+            #disp_resized_np = disp_resized.squeeze().cpu().numpy()
+            disp_resized_np = disp_resized.squeeze().cpu().detach().numpy()
+            vmax = np.percentile(disp_resized_np, 95)
+            normalizer = mpl.colors.Normalize(vmin=disp_resized_np.min(), vmax=vmax)
+            mapper = cm.ScalarMappable(norm=normalizer, cmap='magma')
+            colormapped_im = (mapper.to_rgba(disp_resized_np)[:, :, :3] * 255).astype(np.uint8)
+            im = pil.fromarray(colormapped_im)
+
+        return colormapped_im
+        
+
+if __name__=="__main__":
+    # Webcam depth
+    import cv2
+    cap = cv2.VideoCapture(0)
+    m = monodepth2()
+
+    plt.ion()
+    # plt.draw()
+    plt.show(block=False)
+
+    ax1 = plt.subplot(1,2,1)
+    ax2 = plt.subplot(1,2,2)
+
+    while(True):
+        try:
+            # Capture the video frame
+            # by frame
+            ret, frame = cap.read()
+
+            #frame = cv2.imread('monodepth2/assets/test_image.jpg')
+        
+            # Display the resulting frame
+            depth = m.eval(frame)
+
+            ax1.imshow(frame)
+            ax2.imshow(depth)
+            
+            #cv2.imwrite('tmps/frame.png', frame)
+            #cv2.imwrite('tmps/depth.png', depth)
+            #depth.save('depth.jpeg')
+            
+            # the 'q' button is set as the
+            # quitting button you may use any
+            # desired button of your choice
+            #time.sleep(0.01)
+            plt.pause(0.001)
+        except:
+             break
+    
+    plt.show()
+    
+    # After the loop release the cap object
+    cap.release()
+    # Destroy all the windows
+    cv2.destroyAllWindows()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+from os import path
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setuptools.setup(
+    name="monodepth2",
+    version="0.1.0",
+    packages=['.', 'networks'],
+    scripts=[],
+    license='LICENSE',
+    url='https://github.com/AdityaNG/monodepth2',
+    description="[ICCV 2019] Monocular depth estimation from a single image",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    python_requires='>=3.6',
+)

--- a/test_simple.py
+++ b/test_simple.py
@@ -20,7 +20,7 @@ from torchvision import transforms, datasets
 
 import networks
 from layers import disp_to_depth
-from utils import download_model_if_doesnt_exist
+from utils import download_model_if_doesnt_exist, monodepth2_models_path
 from evaluate_depth import STEREO_SCALE_FACTOR
 
 
@@ -71,7 +71,7 @@ def test_simple(args):
               "models. For mono-trained models, output depths will not in metric space.")
 
     download_model_if_doesnt_exist(args.model_name)
-    model_path = os.path.join("models", args.model_name)
+    model_path = os.path.join(monodepth2_models_path, args.model_name)
     print("-> Loading model from ", model_path)
     encoder_path = os.path.join(model_path, "encoder.pth")
     depth_decoder_path = os.path.join(model_path, "depth.pth")

--- a/trainer.py
+++ b/trainer.py
@@ -574,7 +574,7 @@ class Trainer:
     def save_opts(self):
         """Save options to disk so we know what we ran this experiment with
         """
-        models_dir = os.path.join(self.log_path, "models")
+        models_dir = os.path.join(self.log_path, monodepth2_models_path)
         if not os.path.exists(models_dir):
             os.makedirs(models_dir)
         to_save = self.opt.__dict__.copy()
@@ -585,7 +585,7 @@ class Trainer:
     def save_model(self):
         """Save model weights to disk
         """
-        save_folder = os.path.join(self.log_path, "models", "weights_{}".format(self.epoch))
+        save_folder = os.path.join(self.log_path, monodepth2_models_path, "weights_{}".format(self.epoch))
         if not os.path.exists(save_folder):
             os.makedirs(save_folder)
 

--- a/utils.py
+++ b/utils.py
@@ -47,6 +47,7 @@ def sec_to_hm_str(t):
     h, m, s = sec_to_hm(t)
     return "{:02d}h{:02d}m{:02d}s".format(h, m, s)
 
+monodepth2_models_path = os.path.join(os.path.expanduser('~'), '.monodepth2_models')
 
 def download_model_if_doesnt_exist(model_name):
     """If pretrained kitti model doesn't exist, download and unzip it
@@ -82,10 +83,10 @@ def download_model_if_doesnt_exist(model_name):
              "cdc5fc9b23513c07d5b19235d9ef08f7"),
         }
 
-    if not os.path.exists("models"):
-        os.makedirs("models")
+    if not os.path.exists(monodepth2_models_path):
+        os.makedirs(monodepth2_models_path)
 
-    model_path = os.path.join("models", model_name)
+    model_path = os.path.join(monodepth2_models_path, model_name)
 
     def check_file_matches_md5(checksum, fpath):
         if not os.path.exists(fpath):


### PR DESCRIPTION
Having a pip module of monodepth2 is useful for people working on projects to be able to quickly install and run. I have implemented the installation flow along with a class as a wrapper for monodepth2.

# Installation and Usage
Have added instructions to use the module in the `README.md`, in summary 

```bash
# Installation
pip install git+https://github.com/AdityaNG/monodepth2@pip-module
```
```python
# Running
from monodepth2  import monodepth2
md = monodepth2()
# Load in a frame
depth = md.eval(frame)
```

# Class Features
The class allows users to
- Choose the pre-trained model name
- Enable /  Disable CUDA usage 
- Pass numpy array as input image
- returns numpy array as output

# Webcam Demo

Added a demo to use the webcam and output the depthmap for the video
```shell
python -m monodepth2
```

# Caching
Caching of the models has been moved to `~/.monodepth2_models/` to simplify downloading and storing of models into one common directory for the user as opposed to the current-working-directory + `models/` path. This was done my writing to a global variable `monodepth2_models_path` in the utils