### PR TITLE
use randn on GPU instead of cpu

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -466,7 +466,7 @@ class Trainer:
             if not self.opt.disable_automasking:
                 # add random numbers to break ties
                 identity_reprojection_loss += torch.randn(
-                    identity_reprojection_loss.shape).cuda() * 0.00001
+                    identity_reprojection_loss.shape, device=self.device) * 0.00001
 
                 combined = torch.cat((identity_reprojection_loss, reprojection_loss), dim=1)
             else:


### PR DESCRIPTION
This one change improved training time by 1h+ (10%+ faster) since it reduces a CPU bottleneck during training.

Before
![2022-01-28-171553_1818x909_scrot](https://user-images.githubusercontent.com/909104/151641877-c849140d-8fa3-4477-8f88-1b4980bf454c.png)

After:
![2022-01-28-172205_1817x893_scrot](https://user-images.githubusercontent.com/909104/151641874-38ad1791-551f-4fe5-844c-ef0e9c85b5dd.png)

```
Fri Jan 28 17:26:22 2022
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 495.46       Driver Version: 495.46       CUDA Version: 11.5     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   2  NVIDIA GeForce ...  On   | 00000000:07:00.0 Off |                  N/A |
| 90%   67C    P2   283W / 300W |  18579MiB / 24265MiB |    100%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```
With the change the GPU now shows at 100% utilization
