### PR TITLE
Avoided using batch_size to initialize layers to reconstruct images

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -139,31 +139,30 @@ class Conv3x3(nn.Module):
 class BackprojectDepth(nn.Module):
     """Layer to transform a depth image into a point cloud
     """
-    def __init__(self, batch_size, height, width):
+    def __init__(self, height, width):
         super(BackprojectDepth, self).__init__()
 
-        self.batch_size = batch_size
         self.height = height
         self.width = width
 
         meshgrid = np.meshgrid(range(self.width), range(self.height), indexing='xy')
         self.id_coords = np.stack(meshgrid, axis=0).astype(np.float32)
-        self.id_coords = nn.Parameter(torch.from_numpy(self.id_coords),
-                                      requires_grad=False)
+        self.id_coords = torch.from_numpy(self.id_coords)
 
-        self.ones = nn.Parameter(torch.ones(self.batch_size, 1, self.height * self.width),
+        self.ones = nn.Parameter(torch.ones(1, 1, self.height * self.width),
                                  requires_grad=False)
 
         self.pix_coords = torch.unsqueeze(torch.stack(
             [self.id_coords[0].view(-1), self.id_coords[1].view(-1)], 0), 0)
-        self.pix_coords = self.pix_coords.repeat(batch_size, 1, 1)
         self.pix_coords = nn.Parameter(torch.cat([self.pix_coords, self.ones], 1),
                                        requires_grad=False)
 
     def forward(self, depth, inv_K):
+        batch_size = depth.shape[0]
         cam_points = torch.matmul(inv_K[:, :3, :3], self.pix_coords)
-        cam_points = depth.view(self.batch_size, 1, -1) * cam_points
-        cam_points = torch.cat([cam_points, self.ones], 1)
+        cam_points = depth.view(batch_size, 1, -1) * cam_points
+        cam_points = torch.cat(
+                [cam_points, self.ones.expand(batch_size, -1, -1)], 1)
 
         return cam_points
 
@@ -171,21 +170,20 @@ class BackprojectDepth(nn.Module):
 class Project3D(nn.Module):
     """Layer which projects 3D points into a camera with intrinsics K and at position T
     """
-    def __init__(self, batch_size, height, width, eps=1e-7):
+    def __init__(self, height, width, eps=1e-7):
         super(Project3D, self).__init__()
 
-        self.batch_size = batch_size
         self.height = height
         self.width = width
         self.eps = eps
 
     def forward(self, points, K, T):
+        batch_size = points.shape[0]
         P = torch.matmul(K, T)[:, :3, :]
-
         cam_points = torch.matmul(P, points)
 
         pix_coords = cam_points[:, :2, :] / (cam_points[:, 2, :].unsqueeze(1) + self.eps)
-        pix_coords = pix_coords.view(self.batch_size, 2, self.height, self.width)
+        pix_coords = pix_coords.view(batch_size, 2, self.height, self.width)
         pix_coords = pix_coords.permute(0, 2, 3, 1)
         pix_coords[..., 0] /= self.width - 1
         pix_coords[..., 1] /= self.height - 1

--- a/trainer.py
+++ b/trainer.py
@@ -152,10 +152,10 @@ class Trainer:
             h = self.opt.height // (2 ** scale)
             w = self.opt.width // (2 ** scale)
 
-            self.backproject_depth[scale] = BackprojectDepth(self.opt.batch_size, h, w)
+            self.backproject_depth[scale] = BackprojectDepth(h, w)
             self.backproject_depth[scale].to(self.device)
 
-            self.project_3d[scale] = Project3D(self.opt.batch_size, h, w)
+            self.project_3d[scale] = Project3D(h, w)
             self.project_3d[scale].to(self.device)
 
         self.depth_metric_names = [


### PR DESCRIPTION
Dear monodepth2 authors,

I noticed batch_size is required by the constructors of BackprojectDepth and Project3D. I removed this explicit dependency because it is likely to complicate further designs based on the repository and not beneficial in any perspectives. I also avoided wrapping self.id_coords with nn.Parameter although the change only saves ignorable GPU memory.

Best Regards,
Bolian