### PR TITLE
Update mono_dataset.py, fix 'tuple' not callable

### DIFF
--- a/datasets/mono_dataset.py
+++ b/datasets/mono_dataset.py
@@ -173,7 +173,7 @@ class MonoDataset(data.Dataset):
             inputs[("inv_K", scale)] = torch.from_numpy(inv_K)
 
         if do_color_aug:
-            color_aug = transforms.ColorJitter.get_params(
+            color_aug = transforms.ColorJitter(
                 self.brightness, self.contrast, self.saturation, self.hue)
         else:
             color_aug = (lambda x: x)


### PR DESCRIPTION
transforms.ColorJitter.get_params returns a tuple which is not callable. Directly use color_aug = transforms.ColorJitter